### PR TITLE
修正一处翻译错误

### DIFF
--- a/Chapter10/sequence_modeling_rnn.tex
+++ b/Chapter10/sequence_modeling_rnn.tex
@@ -663,7 +663,7 @@ $\Vo$通常缺乏过去的重要信息，除非它非常高维且内容丰富。
 \label{fig:chap10_rnn_encdec}
 \end{figure}
 
-如果上下文$C$是一个向量，则\gls{encoder}~\glssymbol{RNN}~只是在\secref{sec:modeling_sequences_conditioned_on_context_with_rnns}描述的向量到序列~\glssymbol{RNN}。
+如果上下文$C$是一个向量，则\gls{decoder}~\glssymbol{RNN}~只是在\secref{sec:modeling_sequences_conditioned_on_context_with_rnns}描述的向量到序列~\glssymbol{RNN}。
 正如我们所见，向量到序列~\glssymbol{RNN}~至少有两种接受输入的方法。
 输入可以被提供为~\glssymbol{RNN}~的初始状态，或连接到每个\gls{time_step}中的\gls{hidden_unit}。
 这两种方式也可以结合。


### PR DESCRIPTION
此处翻译为 编码器 encoder，应改为 解码器 decoder。