### PR TITLE
修正章节 6.2.1.1 中的一处翻译错误

### DIFF
--- a/Chapter20/deep_generative_models.tex
+++ b/Chapter20/deep_generative_models.tex
@@ -1508,7 +1508,7 @@ $\vcenter{\hbox{
 \gls{generator_network}学习跟踪其点在某种程度上类似于训练点的流形，而不是最大化特定点的对数概率。
 有点矛盾的是，这意味着模型可以将负无穷大的对数似然分配给测试集，同时仍然表示人类观察者判断为能捕获生成任务本质的流形。
 这不是明显的优点或缺点，并且只要向\gls{generator_network}最后一层所有生成的值添加高斯噪声，就可以保证\gls{generator_network}向所有点分配非零概率。
-以这种方式添加高斯噪声的\gls{generator_network}从相同分布的采样，即使用\gls{generator_network}参数化条件\gls{gaussian_distribution}的均值所获得的分布。
+以这种方式添加高斯噪声的\gls{generator_network}，从中采样的分布，和使用\gls{generator_network}参数化条件\gls{gaussian_distribution}的均值所获得的分布是相同的。
 
 % -- 692 --
 


### PR DESCRIPTION
订正 6.2.1.1 节中的一处翻译错误: "这种等价性并不要求$f(\Vx; \Vtheta)$用于预测\gls{gaussian_distribution}的均值。" -> "这种等价性对于预测\gls{gaussian_distribution}均值的任何函数$f(\Vx; \Vtheta)$都是成立的。"
这句话的原文是 "the equivalence holds regardless of the function used to predict the mean of the Gaussian.". 其中 "used to predict the mean of the Gaussian" 是 function 的修饰语, 句子的主干是 "the equivalence holds regardless of the function". 此外, 从推导过程中也可以发现这种等价性是依赖于高斯分布的假设的。